### PR TITLE
Minimized quantity of output labels

### DIFF
--- a/src/chess_zero/agent/api_chess.py
+++ b/src/chess_zero/agent/api_chess.py
@@ -18,5 +18,3 @@ class ChessModelAPI:
             return policy[0], value[0]
         else:
             return policy, value
-
-

--- a/src/chess_zero/agent/model_chess.py
+++ b/src/chess_zero/agent/model_chess.py
@@ -3,7 +3,7 @@ import json
 import os
 from logging import getLogger
 # noinspection PyPep8Naming
-import keras.backend as K
+import keras.backend as k
 
 from keras.engine.topology import Input
 from keras.engine.training import Model
@@ -103,7 +103,7 @@ class ChessModel:
 
 def objective_function_for_policy(y_true, y_pred):
     # can use categorical_crossentropy??
-    return K.sum(-y_true * K.log(y_pred + K.epsilon()), axis=-1)
+    return k.sum(-y_true * k.log(y_pred + k.epsilon()), axis=-1)
 
 
 def objective_function_for_value(y_true, y_pred):

--- a/src/chess_zero/config.py
+++ b/src/chess_zero/config.py
@@ -15,32 +15,31 @@ def create_uci_labels():
     letters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
     numbers = ['1', '2', '3', '4', '5', '6', '7', '8']
     promoted_to = ['q', 'r', 'b', 'n']
-    pairs = []
-    pairs_promoted = []
-    for l in letters:
-        for n in numbers:
-            pairs.append(l + n)
-            if n == '1' or n == '8':
-                for p in promoted_to:
-                    pairs_promoted.append(l + n + p)
 
-    for p1 in pairs:
-        for p2 in pairs:
-            if p1 != p2:
-                try:
-                    _ = chess.Move.from_uci(p1 + p2)
-                    labels_array.append(p1 + p2)
-                except:
-                    pass
-
-    for p1 in pairs:
-        for pro in pairs_promoted:
-            try:
-                _ = chess.Move.from_uci(p1 + pro)
-                labels_array.append(p1 + pro)
-            except:
-                pass
-
+    for l1 in range(8):
+        for n1 in range(8):
+            destinations = [(t, n1) for t in range(0,8)] + \
+                           [(l1, t) for t in range(0,8)] + \
+                           [(l1 + t, n1 + t) for t in range(-7,8)] + \
+                           [(l1 + t, n1 - t) for t in range(-7,8)] + \
+                           [(l1 + a, n1 + b) for (a, b) in [(-2, -1), (-1, -2), (-2, 1), (1, -2), (2, -1), (-1, 2), (2, 1), (1, 2)]]
+            for (l2, n2) in destinations:
+                if (l1, n1) != (l2, n2) and l2 in range(0,8) and n2 in range(0,8):
+                    move = letters[l1] + numbers[n1] + letters[l2] + numbers[n2]
+                    labels_array.append(move)
+    for l1 in range(8):
+        l = letters[l1]
+        for p in promoted_to:
+            labels_array.append(l + '2' + l + '1' + p)
+            labels_array.append(l + '7' + l + '8' + p)
+            if l1 > 0:
+                l_l = letters[l1 - 1]
+                labels_array.append(l + '2' + l_l + '1' + p)
+                labels_array.append(l + '7' + l_l + '8' + p)
+            if l1 < 7:
+                l_r = letters[l1 + 1]
+                labels_array.append(l + '2' + l_r + '1' + p)
+                labels_array.append(l + '7' + l_r + '8' + p)
     return labels_array
 
 

--- a/src/chess_zero/configs/mini.py
+++ b/src/chess_zero/configs/mini.py
@@ -35,7 +35,7 @@ class PlayConfig:
 
 class TrainerConfig:
     def __init__(self):
-        self.batch_size = 2048
+        self.batch_size = 32 # 2048
         self.epoch_to_checkpoint = 1
         self.start_total_steps = 0
         self.save_model_steps = 1000

--- a/src/chess_zero/env/chess_env.py
+++ b/src/chess_zero/env/chess_env.py
@@ -62,14 +62,10 @@ class ChessEnv:
                 self.winner = Winner.black
             else:
                 val_black, val_white = self.score_board()
-                if self.turn == chess.BLACK and val_black > val_white:
+                if val_black > val_white:
                     self.winner = Winner.black
-                elif self.turn == chess.BLACK and val_black < val_white:
+                elif val_black < val_white:
                     self.winner = Winner.white
-                elif self.turn == chess.WHITE and val_white > val_black:
-                    self.winner = Winner.white
-                elif self.turn == chess.WHITE and val_white < val_black:
-                    self.winner = Winner.black
                 else:
                     self.winner = Winner.draw
 
@@ -83,7 +79,7 @@ class ChessEnv:
     def score_board(self):
         board_state = self.replace_tags()
         pieces_white = [val if val.isupper() and val != "1" else 0 for val in board_state.split(" ")[0]]
-        pieces_black = [val if not val.isupper() and val != "1" else 0 for val in board_state.split(" ")[0]]
+        pieces_black = [val if val.islower() and val != "1" else 0 for val in board_state.split(" ")[0]]
         val_white = 0.0
         val_black = 0.0
         for piece in pieces_white:
@@ -127,7 +123,7 @@ class ChessEnv:
         board_white = [ord(val) if val.isupper() and val != "1" else 0 for val in board_state.split(" ")[0]]
         board_white = np.reshape(board_white, (8, 8))
         # Only black plane
-        board_black = [ord(val) if not val.isupper() and val != "1" else 0 for val in board_state.split(" ")[0]]
+        board_black = [ord(val) if val.islower() and val != "1" else 0 for val in board_state.split(" ")[0]]
         board_black = np.reshape(board_black, (8, 8))
 
         return board_white, board_black
@@ -153,5 +149,3 @@ class ChessEnv:
     @property
     def observation(self):
         return self.board.fen()
-
-

--- a/src/chess_zero/lib/model_helper.py
+++ b/src/chess_zero/lib/model_helper.py
@@ -1,0 +1,36 @@
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+
+def load_best_model_weight(model):
+    """
+
+    :param chess_zero.agent.model.ChessModel model:
+    :return:
+    """
+    return model.load(model.config.resource.model_best_config_path, model.config.resource.model_best_weight_path)
+
+
+def save_as_best_model(model):
+    """
+
+    :param chess_zero.agent.model.ChessModel model:
+    :return:
+    """
+    return model.save(model.config.resource.model_best_config_path, model.config.resource.model_best_weight_path)
+
+
+def reload_best_model_weight_if_changed(model):
+    """
+
+    :param chess_zero.agent.model.ChessModel model:
+    :return:
+    """
+    logger.debug(f"start reload the best model if changed")
+    digest = model.fetch_digest(model.config.resource.model_best_weight_path)
+    if digest != model.digest:
+        return load_best_model_weight(model)
+
+    logger.debug(f"the best model is not changed")
+    return False

--- a/src/chess_zero/lib/tf_util.py
+++ b/src/chess_zero/lib/tf_util.py
@@ -7,7 +7,7 @@ def set_session_config(per_process_gpu_memory_fraction=None, allow_growth=None):
     :return:
     """
     import tensorflow as tf
-    import keras.backend as K
+    import keras.backend as k
 
     config = tf.ConfigProto(
         gpu_options=tf.GPUOptions(
@@ -16,4 +16,4 @@ def set_session_config(per_process_gpu_memory_fraction=None, allow_growth=None):
         )
     )
     sess = tf.Session(config=config)
-    K.set_session(sess)
+    k.set_session(sess)

--- a/src/chess_zero/manager.py
+++ b/src/chess_zero/manager.py
@@ -37,7 +37,7 @@ def start():
 
     logger.info(f"config type: {config_type}")
 
-    if args.cmd == "self":
+    if args.cmd == 'self':
         from .worker import self_play
         return self_play.start(config)
     elif args.cmd == 'opt':

--- a/src/chess_zero/play_game/game_model.py
+++ b/src/chess_zero/play_game/game_model.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from chess_zero.agent.player_chess import HistoryItem
 from chess_zero.agent.player_chess import ChessPlayer
 from chess_zero.config import Config
-from chess_zero.lib.model_helpler import load_best_model_weight
+from chess_zero.lib.model_helper import load_best_model_weight
 import chess
 
 logger = getLogger(__name__)
@@ -27,7 +27,7 @@ class PlayWithHuman:
         from chess_zero.agent.model_chess import ChessModel
         model = ChessModel(self.config)
         if not load_best_model_weight(model):
-            raise RuntimeError("best model not found!")
+            raise RuntimeError("Best model not found!")
         return model
 
     def move_by_ai(self, env):
@@ -35,17 +35,17 @@ class PlayWithHuman:
 
         self.last_history = self.ai.ask_thought_about(env.observation)
         self.last_evaluation = self.last_history.values[self.last_history.action]
-        logger.debug(f"evaluation by ai={self.last_evaluation}")
+        logger.debug(f"Evaluation by AI = {self.last_evaluation}")
 
         return action
 
     def move_by_human(self, env):
         while True:
             try:
-                movement = input('\nEnter your movement in UCI format(a1a2, b2b6,...): ')
-                if chess.Move.from_uci(movement) in env.board.legal_moves:
-                    return movement
+                move = input('\nEnter your move in UCI format (a1a2, b2b6, ...): ')
+                if chess.Move.from_uci(move) in env.board.legal_moves:
+                    return move
                 else:
-                    print("That is NOT a valid movement :(.")
+                    print("That is NOT a valid move :(.")
             except:
-                print("That is NOT a valid movement :(.")
+                print("That is NOT a valid move :(.")

--- a/src/chess_zero/play_game/gui.py
+++ b/src/chess_zero/play_game/gui.py
@@ -18,24 +18,16 @@ def start(config: Config):
     chess_model.start_game(human_is_black)
 
     while not env.done:
-        if env.board.turn == chess.BLACK:
-            if not human_is_black:
-                action = chess_model.move_by_ai(env)
-                print("IA moves to: " + action)
-            else:
-                action = chess_model.move_by_human(env)
-                print("You move to: " + action)
+        if (env.board.turn == chess.BLACK) == human_is_black:
+            action = chess_model.move_by_human(env)
+            print("You move to: " + action)
         else:
-            if human_is_black:
-                action = chess_model.move_by_ai(env)
-                print("IA moves to: " + action)
-            else:
-                action = chess_model.move_by_human(env)
-                print("You move to: " + action)
+            action = chess_model.move_by_ai(env)
+            print("AI moves to: " + action)
         board, info = env.step(action)
         env.render()
-        print("Board fen = " + board.fen())
+        print("Board FEN = " + board.fen())
 
-    print("\nEnd of the game.")
-    print("Game result:")
+    print("\nEnd of the game.") #spaces after this?
+    print("Game result:") #and this?
     print(env.board.result())

--- a/src/chess_zero/run.py
+++ b/src/chess_zero/run.py
@@ -8,6 +8,7 @@ if find_dotenv():
 
 _PATH_ = os.path.dirname(os.path.dirname(__file__))
 
+
 if _PATH_ not in sys.path:
     sys.path.append(_PATH_)
 

--- a/src/chess_zero/worker/evaluate.py
+++ b/src/chess_zero/worker/evaluate.py
@@ -9,7 +9,7 @@ from chess_zero.config import Config
 from chess_zero.env.chess_env import ChessEnv, Winner
 from chess_zero.lib import tf_util
 from chess_zero.lib.data_helper import get_next_generation_model_dirs
-from chess_zero.lib.model_helpler import save_as_best_model, load_best_model_weight
+from chess_zero.lib.model_helper import save_as_best_model, load_best_model_weight
 
 logger = getLogger(__name__)
 

--- a/src/chess_zero/worker/optimize.py
+++ b/src/chess_zero/worker/optimize.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from logging import getLogger
 from time import sleep
 
-import keras.backend as K
+import keras.backend as k
 import numpy as np
 from keras.optimizers import SGD
 
@@ -13,7 +13,7 @@ from chess_zero.config import Config
 from chess_zero.lib import tf_util
 from chess_zero.lib.data_helper import get_game_data_filenames, read_game_data_from_file, \
     get_next_generation_model_dirs
-from chess_zero.lib.model_helpler import load_best_model_weight
+from chess_zero.lib.model_helper import load_best_model_weight
 from chess_zero.env.chess_env import ChessEnv
 import chess
 
@@ -89,7 +89,7 @@ class OptimizeWorker:
             lr = 1e-4
         else:
             lr = 2.5e-5  # means (1e-4 / 4): the paper batch size=2048, ours is 512.
-        K.set_value(self.optimizer.lr, lr)
+        k.set_value(self.optimizer.lr, lr)
         logger.debug(f"total step={total_steps}, set learning rate to {lr}")
 
     def save_current_model(self):

--- a/src/chess_zero/worker/self_play.py
+++ b/src/chess_zero/worker/self_play.py
@@ -8,14 +8,14 @@ from chess_zero.config import Config
 from chess_zero.env.chess_env import ChessEnv, Winner
 from chess_zero.lib import tf_util
 from chess_zero.lib.data_helper import get_game_data_filenames, write_game_data_to_file
-from chess_zero.lib.model_helpler import load_best_model_weight, save_as_best_model, \
+from chess_zero.lib.model_helper import load_best_model_weight, save_as_best_model, \
     reload_best_model_weight_if_changed
 
 logger = getLogger(__name__)
 
 
 def start(config: Config):
-    tf_util.set_session_config(per_process_gpu_memory_fraction=0.75)
+    tf_util.set_session_config(per_process_gpu_memory_fraction=0.5)
     return SelfPlayWorker(config, env=ChessEnv()).start()
 
 
@@ -107,5 +107,3 @@ class SelfPlayWorker:
             model.build()
             save_as_best_model(model)
         return model
-
-


### PR DESCRIPTION
Main change: modified the `create_uci_labels` routine so as to generate only those labels which can conceivably appear as legal chess moves (e.g. `a1h8` but not `a1h7`). This leads to much fewer output features for the neural network (1968 instead of 8128) and to speedups.

Also made a few minor typographical changes.