### PR TITLE
Onehot syzygy

### DIFF
--- a/src/chess_zero/agent/api_chess.py
+++ b/src/chess_zero/agent/api_chess.py
@@ -8,10 +8,10 @@ class ChessModelAPI:
 
     def predict(self, x):
         assert x.ndim in (3, 4)
-        assert x.shape == (2, 8, 8) or x.shape[1:] == (2, 8, 8)
+        assert x.shape == (12, 8, 8) or x.shape[1:] == (12, 8, 8)
         orig_x = x
         if x.ndim == 3:
-            x = x.reshape(1, 2, 8, 8)
+            x = x.reshape(1, 12, 8, 8)
         policy, value = self.agent_model.model.predict_on_batch(x)
 
         if orig_x.ndim == 3:

--- a/src/chess_zero/agent/model_chess.py
+++ b/src/chess_zero/agent/model_chess.py
@@ -27,11 +27,10 @@ class ChessModel:
 
     def build(self):
         mc = self.config.model
-        in_x = x = Input((2, 8, 8))  # [own(8x8), enemy(8x8)]
+        in_x = x = Input((12, 8, 8))  # [own(8x8), enemy(8x8)]
 
         # (batch, channels, height, width)
-        x = Conv2D(filters=mc.cnn_filter_num, kernel_size=mc.cnn_filter_size, padding="same",
-                   data_format="channels_first", kernel_regularizer=l2(mc.l2_reg))(x)
+        x = Conv2D(filters=mc.cnn_filter_num, kernel_size=mc.cnn_filter_size, padding="same", data_format="channels_first", kernel_regularizer=l2(mc.l2_reg))(x)
         x = BatchNormalization(axis=1)(x)
         x = Activation("relu")(x)
 

--- a/src/chess_zero/config.py
+++ b/src/chess_zero/config.py
@@ -9,6 +9,8 @@ def _project_dir():
 def _data_dir():
     return os.path.join(_project_dir(), "data")
 
+def _syzygy_dir():
+    return os.path.join(_project_dir(), "syzygy")
 
 def create_uci_labels():
     labels_array = []
@@ -18,13 +20,13 @@ def create_uci_labels():
 
     for l1 in range(8):
         for n1 in range(8):
-            destinations = [(t, n1) for t in range(0,8)] + \
-                           [(l1, t) for t in range(0,8)] + \
+            destinations = [(t, n1) for t in range(8)] + \
+                           [(l1, t) for t in range(8)] + \
                            [(l1 + t, n1 + t) for t in range(-7,8)] + \
                            [(l1 + t, n1 - t) for t in range(-7,8)] + \
                            [(l1 + a, n1 + b) for (a, b) in [(-2, -1), (-1, -2), (-2, 1), (1, -2), (2, -1), (-1, 2), (2, 1), (1, 2)]]
             for (l2, n2) in destinations:
-                if (l1, n1) != (l2, n2) and l2 in range(0,8) and n2 in range(0,8):
+                if (l1, n1) != (l2, n2) and l2 in range(8) and n2 in range(8):
                     move = letters[l1] + numbers[n1] + letters[l2] + numbers[n2]
                     labels_array.append(move)
     for l1 in range(8):
@@ -50,6 +52,8 @@ class Config:
 
         if config_type == "mini":
             import chess_zero.configs.mini as c
+        elif config_type == "small":
+            import chess_zero.configs.small as c
         elif config_type == "normal":
             import chess_zero.configs.normal as c
         else:
@@ -74,6 +78,7 @@ class ResourceConfig:
         self.model_dir = os.environ.get("MODEL_DIR", os.path.join(self.data_dir, "model"))
         self.model_best_config_path = os.path.join(self.model_dir, "model_best_config.json")
         self.model_best_weight_path = os.path.join(self.model_dir, "model_best_weight.h5")
+        self.syzygy_dir = os.environ.get("SYZYGY_DIR", _syzygy_dir())
 
         self.next_generation_model_dir = os.path.join(self.model_dir, "next_generation")
         self.next_generation_model_dirname_tmpl = "model_%s"
@@ -87,8 +92,7 @@ class ResourceConfig:
         self.main_log_path = os.path.join(self.log_dir, "main.log")
 
     def create_directories(self):
-        dirs = [self.project_dir, self.data_dir, self.model_dir, self.play_data_dir, self.log_dir,
-                self.next_generation_model_dir]
+        dirs = [self.project_dir, self.data_dir, self.model_dir, self.play_data_dir, self.log_dir, self.next_generation_model_dir, self.syzygy_dir]
         for d in dirs:
             if not os.path.exists(d):
                 os.makedirs(d)

--- a/src/chess_zero/configs/normal.py
+++ b/src/chess_zero/configs/normal.py
@@ -1,6 +1,6 @@
 class EvaluateConfig:
     def __init__(self):
-        self.game_num = 100 #  400
+        self.game_num = 100  # 400
         self.replace_rate = 0.55
         self.play_config = PlayConfig()
         self.play_config.c_puct = 1
@@ -12,7 +12,7 @@ class EvaluateConfig:
 class PlayDataConfig:
     def __init__(self):
         self.nb_game_in_file = 100
-        self.max_file_num = 200 # 5000
+        self.max_file_num = 200  # 5000
 
 
 class PlayConfig:
@@ -29,13 +29,13 @@ class PlayConfig:
         self.parallel_search_num = 16
         self.prediction_worker_sleep_sec = 0.0001
         self.wait_for_expanding_sleep_sec = 0.00001
-        self.resign_threshold = None # -1.0
+        self.resign_threshold = None  # -1.0
         self.min_resign_turn = 10
 
 
 class TrainerConfig:
     def __init__(self):
-        self.batch_size = 512 # 2048
+        self.batch_size = 512  # 2048
         self.epoch_to_checkpoint = 1
         self.start_total_steps = 0
         self.save_model_steps = 2000

--- a/src/chess_zero/configs/normal.py
+++ b/src/chess_zero/configs/normal.py
@@ -1,6 +1,6 @@
 class EvaluateConfig:
     def __init__(self):
-        self.game_num = 100 # 400
+        self.game_num = 100 #  400
         self.replace_rate = 0.55
         self.play_config = PlayConfig()
         self.play_config.c_puct = 1

--- a/src/chess_zero/configs/normal.py
+++ b/src/chess_zero/configs/normal.py
@@ -1,6 +1,6 @@
 class EvaluateConfig:
     def __init__(self):
-        self.game_num = 50 # 400
+        self.game_num = 100 # 400
         self.replace_rate = 0.55
         self.play_config = PlayConfig()
         self.play_config.c_puct = 1

--- a/src/chess_zero/configs/normal.py
+++ b/src/chess_zero/configs/normal.py
@@ -1,10 +1,8 @@
 class EvaluateConfig:
     def __init__(self):
-        self.game_num = 100  # 400
+        self.game_num = 50 # 400
         self.replace_rate = 0.55
         self.play_config = PlayConfig()
-        self.play_config.simulation_num_per_move = 200
-        self.play_config.thinking_loop = 1
         self.play_config.c_puct = 1
         self.play_config.change_tau_turn = 0
         self.play_config.noise_eps = 0
@@ -14,7 +12,7 @@ class EvaluateConfig:
 class PlayDataConfig:
     def __init__(self):
         self.nb_game_in_file = 100
-        self.max_file_num = 200  # 5000
+        self.max_file_num = 200 # 5000
 
 
 class PlayConfig:
@@ -31,13 +29,13 @@ class PlayConfig:
         self.parallel_search_num = 16
         self.prediction_worker_sleep_sec = 0.0001
         self.wait_for_expanding_sleep_sec = 0.00001
-        self.resign_threshold = -13
-        self.min_resign_turn = 5
+        self.resign_threshold = None # -1.0
+        self.min_resign_turn = 10
 
 
 class TrainerConfig:
     def __init__(self):
-        self.batch_size = 32  # 2048
+        self.batch_size = 512 # 2048
         self.epoch_to_checkpoint = 1
         self.start_total_steps = 0
         self.save_model_steps = 2000

--- a/src/chess_zero/configs/small.py
+++ b/src/chess_zero/configs/small.py
@@ -1,6 +1,6 @@
 class EvaluateConfig:
     def __init__(self):
-        self.game_num = 10
+        self.game_num = 10  # 10
         self.replace_rate = 0.55
         self.play_config = PlayConfig()
         self.play_config.simulation_num_per_move = 50
@@ -13,40 +13,40 @@ class EvaluateConfig:
 
 class PlayDataConfig:
     def __init__(self):
-        self.nb_game_in_file = 20
-        self.max_file_num = 10
+        self.nb_game_in_file = 20  # 100
+        self.max_file_num = 50  # 10
 
 
 class PlayConfig:
     def __init__(self):
-        self.simulation_num_per_move = 10
+        self.simulation_num_per_move = 50  # 10
         self.thinking_loop = 1
         self.logging_thinking = False
-        self.c_puct = 5
+        self.c_puct = 3  # 5
         self.noise_eps = 0.25
         self.dirichlet_alpha = 0.03
         self.change_tau_turn = 10
         self.virtual_loss = 3
         self.prediction_queue_size = 16
-        self.parallel_search_num = 4
+        self.parallel_search_num = 16 # 4
         self.prediction_worker_sleep_sec = 0.00001
         self.wait_for_expanding_sleep_sec = 0.000001
-        self.resign_threshold = None
-        self.min_resign_turn = 5
+        self.resign_threshold = None  #-1.0
+        self.min_resign_turn = 10
 
 
 class TrainerConfig:
     def __init__(self):
-        self.batch_size = 32 # 2048
+        self.batch_size = 512  # 2048
         self.epoch_to_checkpoint = 1
         self.start_total_steps = 0
-        self.save_model_steps = 1000
+        self.save_model_steps = 2000
         self.load_data_steps = 1000
 
 
 class ModelConfig:
-    cnn_filter_num = 16
+    cnn_filter_num = 128
     cnn_filter_size = 3
-    res_layer_num = 1
+    res_layer_num = 7
     l2_reg = 1e-4
-    value_fc_size = 16
+    value_fc_size = 128

--- a/src/chess_zero/env/chess_env.py
+++ b/src/chess_zero/env/chess_env.py
@@ -49,7 +49,7 @@ class ChessEnv:
 
         self.turn += 1
 
-        if self.board.is_game_over() or self.board.can_claim_draw() or self.num_pieces() <= 5: # replace with a direct syzygy probe?
+        if self.board.is_game_over() or self.board.can_claim_draw() or self.num_pieces() <= 5:  # replace with a direct syzygy probe?
             self._game_over()
 
         return self.board, {}

--- a/src/chess_zero/play_game/game_model.py
+++ b/src/chess_zero/play_game/game_model.py
@@ -19,8 +19,8 @@ class PlayWithHuman:
         self.last_evaluation = None
         self.last_history = None  # type: HistoryItem
 
-    def start_game(self, human_is_black):
-        self.human_color = chess.BLACK if human_is_black else chess.WHITE
+    def start_game(self, human_is_white):
+        self.human_color = chess.WHITE if human_is_white else chess.BLACK
         self.ai = ChessPlayer(self.config, self.model)
 
     def _load_model(self):

--- a/src/chess_zero/play_game/gui.py
+++ b/src/chess_zero/play_game/gui.py
@@ -13,7 +13,7 @@ def start(config: Config):
     PlayWithHumanConfig().update_play_config(config.play)
     chess_model = PlayWithHuman(config)
 
-    env = ChessEnv().reset()
+    env = ChessEnv(config.resource.syzygy_dir).reset()
     human_is_black = random() < 0.5
     chess_model.start_game(human_is_black)
 
@@ -28,6 +28,6 @@ def start(config: Config):
         env.render()
         print("Board FEN = " + board.fen())
 
-    print("\nEnd of the game.") #spaces after this?
-    print("Game result:") #and this?
+    print("\nEnd of the game.")
+    print("Game result:")
     print(env.board.result())

--- a/src/chess_zero/worker/evaluate.py
+++ b/src/chess_zero/worker/evaluate.py
@@ -62,7 +62,7 @@ class EvaluateWorker:
                 logger.debug(f"win count has reached {results.count(1)}, so change best model")
                 break
 
-        winning_rate = sum(results) / len(results) if len(results) != 0 else 0
+        winning_rate = sum(results) / len(results)
         logger.debug(f"winning rate {winning_rate*100:.1f}%")
         return winning_rate >= self.config.eval.replace_rate
 


### PR DESCRIPTION
This commit adds two major changes to the previous one. For one, the board, which was previously represented essentially by two 8x8 character arrays, is now represented by 12 8x8 bitboards, one for each piece type. This is advantageous, as the neural network is unlikely to be able to adequately understand the difference between `ord('Q') = 81` and `ord('P') = 80`, say.

Secondly, the use of material counts is entirely eliminated. This facilitates a desirable "heuristic free" approach exemplified by AlphaGo Zero. Yet it introduces two challenges:
1. **How do we determine when to resign early?** Previously, resignations were triggered by a material deficit (-13 points). In this commit, we use the machine's internal evaluator as a resignation threshold, an approach more faithful to that of AlphaGo. Note: we do _not_ yet feature a resignation threshold dynamically determined so as to keep false positives low.
2. **What training signal to send when a game ends in a draw?** The "AlphaGo approach" to chess is made challenging by the fact that most "random" endgames in chess are draws, which results in weak training signals (especially in the early stages). In the earlier commit, drawn endgames were again scored by a material tally. Here, any position whose piece count drops below 6 is immediately evaluated using a syzygy tablebase and scored. In this setting, substantially fewer games end in draws.