### PR TITLE
Tablebases

### DIFF
--- a/src/chess_zero/play_game/gui.py
+++ b/src/chess_zero/play_game/gui.py
@@ -24,9 +24,9 @@ def start(config: Config):
         else:
             action = chess_model.move_by_ai(env)
             print("AI moves to: " + action)
-        board = env.step(action)
+        env.step(action)
         env.render()
-        print("Board FEN = " + board.fen())
+        print("Board FEN = " + env.board.fen())
 
     print("\nEnd of the game.")
     print("Game result:")

--- a/src/chess_zero/play_game/gui.py
+++ b/src/chess_zero/play_game/gui.py
@@ -13,7 +13,7 @@ def start(config: Config):
     PlayWithHumanConfig().update_play_config(config.play)
     chess_model = PlayWithHuman(config)
 
-    env = ChessEnv(config.resource.syzygy_dir).reset()
+    env = ChessEnv().reset()
     human_is_black = random() < 0.5
     chess_model.start_game(human_is_black)
 
@@ -24,7 +24,7 @@ def start(config: Config):
         else:
             action = chess_model.move_by_ai(env)
             print("AI moves to: " + action)
-        board, info = env.step(action)
+        board = env.step(action)
         env.render()
         print("Board FEN = " + board.fen())
 

--- a/src/chess_zero/worker/evaluate.py
+++ b/src/chess_zero/worker/evaluate.py
@@ -63,7 +63,7 @@ class EvaluateWorker:
         return winning_rate >= self.config.eval.replace_rate
 
     def play_game(self, best_model, ng_model):
-        env = ChessEnv(self.config.resource.syzygy_dir).reset()
+        env = ChessEnv().reset()
 
         best_player = ChessPlayer(self.config, best_model, play_config=self.config.eval.play_config)
         ng_player = ChessPlayer(self.config, ng_model, play_config=self.config.eval.play_config)

--- a/src/chess_zero/worker/optimize.py
+++ b/src/chess_zero/worker/optimize.py
@@ -180,7 +180,7 @@ class OptimizeWorker:
         policy_list = []
         z_list = []
         for state, policy, z in data:
-            env = ChessEnv().update(state)  # no syzygy_dir need be passed here; as the method is static (but why?) none could be.
+            env = ChessEnv().update(state)
 
             white_ary, black_ary = env.white_and_black_plane()
             state = [white_ary, black_ary] if env.board.turn == chess.WHITE else [black_ary, white_ary]


### PR DESCRIPTION
The approach to the use of tablebases has been re-thought. A successful tablebase probe now, instead of immediately terminating self-play, *guides* self-play, so that optimal endgame play data is accumulated during training. Whereas the task of checking for a successful probe previously lay with the the `ChessEnv` class--frankly, constituting a violating encapsulation--it now resides within the `ChessPlayer`'s `action` method. In short, in cases where a tablebase probe is possible, the MCTS is simply _bypassed_, and a "fake" policy vector is created in which the optimal move is highlighted.